### PR TITLE
Add support for python 3.x

### DIFF
--- a/osmread/parser/xml.py
+++ b/osmread/parser/xml.py
@@ -36,7 +36,7 @@ class XmlParser(Parser):
             if event == 'start':
                 attrs = elem.attrib
                 if elem.tag in ('node', 'way', 'relation'):
-                    _id = long(attrs['id'])
+                    _id = attrs['id']
                     _version = int(attrs['version'])
                     _changeset = int(attrs['changeset'])
                     # TODO: improve timestamp parsing - dateutil too slow
@@ -72,21 +72,21 @@ class XmlParser(Parser):
                         _members = []
 
                 elif elem.tag == 'tag':
-                    _tags[unicode(attrs['k'])] = unicode(attrs['v'])
+                    _tags[str(attrs['k'])] = str(attrs['v'])
 
                 elif elem.tag == 'nd':
-                    _nodes.append(long(attrs['ref']))
+                    _nodes.append(attrs['ref'])
 
                 elif elem.tag == 'member':
                     _members.append(
                         RelationMember(
-                            unicode(attrs['role']),
+                            attrs['role'],
                             {
                                 'node': Node,
                                 'way': Way,
                                 'relation': Relation
                             }[attrs['type']],
-                            long(attrs['ref'])
+                            attrs['ref']
                         )
                     )
 

--- a/osmread/parser/xml.py
+++ b/osmread/parser/xml.py
@@ -1,3 +1,4 @@
+import sys
 from lxml.etree import iterparse
 from datetime import datetime
 from time import mktime
@@ -5,6 +6,10 @@ from time import mktime
 from osmread.parser import Parser
 from osmread.elements import Node, Way, Relation, RelationMember
 
+# Support for Python 3.x & 2.x
+if sys.version_info > (3,):
+    long = int
+    unicode = str
 
 class XmlParser(Parser):
 
@@ -36,7 +41,7 @@ class XmlParser(Parser):
             if event == 'start':
                 attrs = elem.attrib
                 if elem.tag in ('node', 'way', 'relation'):
-                    _id = attrs['id']
+                    _id = long(attrs['id'])
                     _version = int(attrs['version'])
                     _changeset = int(attrs['changeset'])
                     # TODO: improve timestamp parsing - dateutil too slow
@@ -72,21 +77,21 @@ class XmlParser(Parser):
                         _members = []
 
                 elif elem.tag == 'tag':
-                    _tags[str(attrs['k'])] = str(attrs['v'])
+                    _tags[unicode(attrs['k'])] = unicode(attrs['v'])
 
                 elif elem.tag == 'nd':
-                    _nodes.append(attrs['ref'])
+                    _nodes.append(long(attrs['ref']))
 
                 elif elem.tag == 'member':
                     _members.append(
                         RelationMember(
-                            attrs['role'],
+                            unicode(attrs['role']),
                             {
                                 'node': Node,
                                 'way': Way,
                                 'relation': Relation
                             }[attrs['type']],
-                            attrs['ref']
+                            long(attrs['ref'])
                         )
                     )
 


### PR DESCRIPTION
- Remove built-in function: long()
- Change unicode() to str() 