### PR TITLE
Fix a syntax error in Python 3.5

### DIFF
--- a/osmread/parser/pbf.py
+++ b/osmread/parser/pbf.py
@@ -105,15 +105,16 @@ class PbfParser(Parser):
         lat_offset = pblock.lat_offset
 
         for e in data:
+            try:
+                uid = e.info.uid,
+            except:
+                uid = 0  # An obj can miss an uid (when anonymous edits were possible)
             yield Node(
                 id=e.id,
                 version=e.info.version,
                 changeset=int(e.info.changeset),
                 timestamp=int(e.info.timestamp),
-                try:
-                    uid=e.info.uid,
-                except:
-                    uid=0 #An obj can miss an uid (when anonymous edits were possible)
+                uid = uid,
                 tags=self.__parse_tags(e, pblock),
                 lon=float(e.lon * granularity + lon_offset) / long(1000000000),
                 lat=float(e.lat * granularity + lat_offset) / long(1000000000),

--- a/osmread/parser/pbf.py
+++ b/osmread/parser/pbf.py
@@ -106,7 +106,7 @@ class PbfParser(Parser):
 
         for e in data:
             try:
-                uid = e.info.uid,
+                uid = e.info.uid
             except:
                 uid = 0  # An obj can miss an uid (when anonymous edits were possible)
             yield Node(


### PR DESCRIPTION
Hi,

When importing the file pbf.py on Python 3.5, I got the following error:

```
Python 3.5.2 |Anaconda custom (x86_64)| (default, Jul  2 2016, 17:52:12) 
[GCC 4.2.1 Compatible Apple LLVM 4.2 (clang-425.0.28)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import pbf
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/rmkujala/work/osmread/osmread/parser/pbf.py", line 113
    try:
      ^
SyntaxError: invalid syntax
>>> 
```

This pull request should fix this syntax error.