### PR TITLE
Flexible change from lxml to xml on failure

### DIFF
--- a/osmread/parser/xml.py
+++ b/osmread/parser/xml.py
@@ -1,7 +1,10 @@
 import sys
-from lxml.etree import iterparse
 from datetime import datetime
 from time import mktime
+try:
+    from lxml.etree import iterparse
+except ImportError:
+    from xml.etree.ElementTree import iterparse
 
 from osmread.parser import Parser
 from osmread.elements import Node, Way, Relation, RelationMember


### PR DESCRIPTION
In the internet several issues like "lxml - ImportError: DLL load failed" can be found even though people have a standard installation. This small change helps them to still use this script.