### PR TITLE
Support geofabrik's public snapshots, which lack a 'changeset' id attribute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea
+*egg*
+*.pyc

--- a/osmread/parser/pbf.py
+++ b/osmread/parser/pbf.py
@@ -109,10 +109,14 @@ class PbfParser(Parser):
                 uid = e.info.uid
             except:
                 uid = 0  # An obj can miss an uid (when anonymous edits were possible)
+            try:
+                cs = int(e.info.changeset)
+            except:
+                cs = 0 # GeoFabrik's (May 2018) public snapshots strip the changeset attribute out of their data
             yield Node(
                 id=e.id,
                 version=e.info.version,
-                changeset=int(e.info.changeset),
+                changeset=cs,
                 timestamp=int(e.info.timestamp),
                 uid = uid,
                 tags=self.__parse_tags(e, pblock),

--- a/osmread/parser/xml.py
+++ b/osmread/parser/xml.py
@@ -46,25 +46,33 @@ class XmlParser(Parser):
                 if elem.tag in ('node', 'way', 'relation'):
                     _id = long(attrs['id'])
                     _version = int(attrs['version'])
-                    _changeset = int(attrs['changeset'])
-                    # TODO: improve timestamp parsing - dateutil too slow
-                    _tstxt = attrs['timestamp']
-                    _timestamp = int((
-                        datetime(
-                            year=int(_tstxt[0:4]),
-                            month=int(_tstxt[5:7]),
-                            day=int(_tstxt[8:10]),
-                            hour=int(_tstxt[11:13]),
-                            minute=int(_tstxt[14:16]),
-                            second=int(_tstxt[17:19]),
-                            tzinfo=None
-                        ) - datetime(
-                            year=1970,
-                            month=1,
-                            day=1,
-                            tzinfo=None
-                        )
-                    ).total_seconds())
+
+                    try: # GeoFabrik's (May 2018) public snapshots strip the changeset attribute out of their data
+                        _changeset = int(attrs['changeset'])
+                    except:
+                        _changeset = 0
+
+                    try: # GeoFabrik's (May 2018) public snapshots strip timestamp attribute out of their data
+                        # TODO: improve timestamp parsing - dateutil too slow
+                        _tstxt = attrs['timestamp']
+                        _timestamp = int((
+                            datetime(
+                                year=int(_tstxt[0:4]),
+                                month=int(_tstxt[5:7]),
+                                day=int(_tstxt[8:10]),
+                                hour=int(_tstxt[11:13]),
+                                minute=int(_tstxt[14:16]),
+                                second=int(_tstxt[17:19]),
+                                tzinfo=None
+                            ) - datetime(
+                                year=1970,
+                                month=1,
+                                day=1,
+                                tzinfo=None
+                            )
+                        ).total_seconds())
+                    except:
+                        _timestamp = 0
 
                     try: #An object can miss an uid (when anonymous edits were possible)
                         _uid = int(attrs['uid'])

--- a/osmread/parser/xml.py
+++ b/osmread/parser/xml.py
@@ -52,27 +52,24 @@ class XmlParser(Parser):
                     except:
                         _changeset = 0
 
-                    try: # GeoFabrik's (May 2018) public snapshots strip timestamp attribute out of their data
-                        # TODO: improve timestamp parsing - dateutil too slow
-                        _tstxt = attrs['timestamp']
-                        _timestamp = int((
-                            datetime(
-                                year=int(_tstxt[0:4]),
-                                month=int(_tstxt[5:7]),
-                                day=int(_tstxt[8:10]),
-                                hour=int(_tstxt[11:13]),
-                                minute=int(_tstxt[14:16]),
-                                second=int(_tstxt[17:19]),
-                                tzinfo=None
-                            ) - datetime(
-                                year=1970,
-                                month=1,
-                                day=1,
-                                tzinfo=None
-                            )
-                        ).total_seconds())
-                    except:
-                        _timestamp = 0
+                    # TODO: improve timestamp parsing - dateutil too slow
+                    _tstxt = attrs['timestamp']
+                    _timestamp = int((
+                        datetime(
+                            year=int(_tstxt[0:4]),
+                            month=int(_tstxt[5:7]),
+                            day=int(_tstxt[8:10]),
+                            hour=int(_tstxt[11:13]),
+                            minute=int(_tstxt[14:16]),
+                            second=int(_tstxt[17:19]),
+                            tzinfo=None
+                        ) - datetime(
+                            year=1970,
+                            month=1,
+                            day=1,
+                            tzinfo=None
+                        )
+                    ).total_seconds())
 
                     try: #An object can miss an uid (when anonymous edits were possible)
                         _uid = int(attrs['uid'])


### PR DESCRIPTION
Geofabrik removed the 'changeset' attribute in May 2018 from their public snapshots.
https://osm-internal.download.geofabrik.de/index.html

This PR prevents the XML parser from throwing an exception on feeds that lack the changeset attribute, by wrapping the parsing of 'changeset' in a try/except.

Also added a .gitignore file